### PR TITLE
Fix bug #647  Non affichage de la page de confirmation de demande d'inscription sur sloop

### DIFF
--- a/templates/register.html
+++ b/templates/register.html
@@ -62,7 +62,7 @@
 
       $('#register-form').on('ajax:success', function(event, json, xhr) {
         var url = json.redirect_url || "${reverse('dashboard')}";
-        location.href = appendParameter(url, "signin", "initial");
+        location.href = url;
       });
 
       $('#register-form').on('ajax:error', function(event, jqXHR, textStatus) {


### PR DESCRIPTION
Après réponse de la requête ajax (post du formulaire d'inscription), le callback 'ajax:success' était bien déclenché. Cependant celui-ci faisait appel à une fonction inexistante et non utilisée (appendParameter()). Le retrait de cette fonction corrige le bug. L'attribut **href** de l’objet **location** est bien modifié par l'url correspondant au dashboard.
